### PR TITLE
Update sell and edit action to add validation

### DIFF
--- a/app/assets/javascripts/sell.js
+++ b/app/assets/javascripts/sell.js
@@ -24,6 +24,7 @@ $(function(){
       $(".overlay").fadeIn(200);
       $(".modal_exhibit-comp").fadeIn(200);
       var path="/products/" + data.product_id;
+      var path="/users/" + data.current_user_id + "/showedit";
       $(".link_to_product").attr("href",path);
     }
     else{
@@ -66,7 +67,7 @@ $(function(){
   }
 
   var files_array = []
-
+  var total_image_max = 10;
   //ドラッグドロップによる画像取得
   $('.item__images__container__guide').on('dragover',function(e){
       e.preventDefault();
@@ -74,29 +75,40 @@ $(function(){
   $('.item__images__container__guide').on('drop',function(event){
     event.preventDefault();
     files = event.originalEvent.dataTransfer.files;
-    for (var i=0; i<files.length; i++) {
-      files_array.push(files[i]);
-      var fileReader = new FileReader();
-      fileReader.onload = function( event ) {
-      var loadedImageUri = event.target.result;      
-      $(buildImage(loadedImageUri,)).appendTo(".item__images__container__preview ul");
-      };
-      fileReader.readAsDataURL(files[i]);
+
+    if( files_array.length + files.length + alreadysavedtotal - delete_request_index.length <= total_image_max){
+      for (var i=0; i<files.length; i++) {
+        files_array.push(files[i]);
+        var fileReader = new FileReader();
+        fileReader.onload = function( event ) {
+          var loadedImageUri = event.target.result;      
+          $(buildImage(loadedImageUri,)).appendTo(".item__images__container__wrapper:last-child .item__images__container__preview ul");
+        };
+        fileReader.readAsDataURL(files[i]);
+      }
+    }
+    else{
+      alert("登録可能な最大数を超えているためアップロードできません。");
     }
   });
-
+  
   // クリック時のイベントの作成
   $('.upload-image').on('change',function(event){
     event.preventDefault();
     files = $(this)[0].files;
-    for (var i=0; i<files.length; i++) {
-      files_array.push(files[i]);
-      var fileReader = new FileReader();
-      fileReader.onload = function( event ) {
-        var loadedImageUri = event.target.result;
-        $(buildImage(loadedImageUri,)).appendTo(".item__images__container__preview ul").trigger("create");
-      };
-      fileReader.readAsDataURL(files[i]);
+    if( files_array.length + files.length + alreadysavedtotal - delete_request_index.length <= total_image_max){
+      for (var i=0; i<files.length; i++) {
+        files_array.push(files[i]);
+        var fileReader = new FileReader();
+        fileReader.onload = function( event ) {
+          var loadedImageUri = event.target.result;
+          $(buildImage(loadedImageUri,)).appendTo(".item__images__container__wrapper:last-child .item__images__container__preview ul").trigger("create").trigger("create");
+        };
+        fileReader.readAsDataURL(files[i]);
+      }
+    }
+    else{
+      alert("登録可能な最大数を超えているためアップロードできません。");
     }
   });
 
@@ -137,19 +149,43 @@ $(function(){
   var money_l = 300;
   var money_h =9999999;
   var fee_rate = 0.1;
-  $(".money_box").on("keyup", function(){
+  if($(".money_box").val()){
     var input_money = $(".money_box").val();
     if(input_money >= money_l && input_money <= money_h){
-      var fee     = input_money*fee_rate;
+      var fee     = Math.floor(input_money*fee_rate);
       var profit  = input_money - fee;
       $(".l-right.fee").html("¥"+fee.toString().replace(/(\d)(?=(\d{3})+$)/g , '$1,'));
       $(".l-right.profit").html("¥"+profit.toString().replace(/(\d)(?=(\d{3})+$)/g , '$1,')); 
     }
+    else{
+      $(".l-right.fee").html("");
+      $(".l-right.profit").html(""); 
+    }
+  }
+  $(".money_box").on("keyup", function(){
+    var input_money = $(".money_box").val();
+    if(input_money >= money_l && input_money <= money_h){
+      var fee     = Math.floor(input_money*fee_rate);
+      var profit  = input_money - fee;
+      $(".l-right.fee").html("¥"+fee.toString().replace(/(\d)(?=(\d{3})+$)/g , '$1,'));
+      $(".l-right.profit").html("¥"+profit.toString().replace(/(\d)(?=(\d{3})+$)/g , '$1,')); 
+    }
+    else{
+      $(".l-right.fee").html("");
+      $(".l-right.profit").html(""); 
+    }
   });
 
+  var alreadysavedtotal = 0;
+  if ( $(".block-image").data("alreadysavedtotal") ){
+    alreadysavedtotal = $(".block-image").data("alreadysavedtotal");
+  }
+  
+  
+
   var delete_request_index = [];
-  $(document).on("click",".delete_btn_box", function(){
-    var index = $(".delete_btn_box").index(this);
+  $(document).on("click",".delete_btn_box2", function(){
+    var index = $(".delete_btn_box2").index(this);
     // クリックされたaタグの順番から、削除すべき画像を特定し、配列から削除する。
     // files_array.splice(index - 1, 1);
     delete_request_index.push($(this).parent().parent().data("alreadysaved"));

--- a/app/assets/stylesheets/_sell.scss
+++ b/app/assets/stylesheets/_sell.scss
@@ -75,7 +75,7 @@ body {
                 }
               }
               .item__images__container__preview__box{
-                display:none;
+                display:block;
                 box-sizing: border-box;
                 margin: 0 auto;
                 height:20px;
@@ -550,6 +550,29 @@ li.sortable-placeholder {
     }
     &__link:hover{
       opacity:0.6;
+    }
+  }
+}
+
+@media screen and (min-width: 768px){
+  .single-main{
+    .sell-form{
+      .sell-upload-box{
+        .item__images__container__wrapper:last-child{
+          .item__images__container__preview ul li{
+            .item__images__container__preview__box{
+              display:none;
+              div{
+                cursor:pointer;
+              }
+              div:hover{
+                cursor:pointer;
+                color:red;
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -102,12 +102,8 @@ class ProductsController < ApplicationController
 
   def destroy
     @product= Product.find(params[:id])
-    
     if @product.destroy
-      
       redirect_to showedit_user_path(current_user)
-    else
-      redirect_to showmain_product_path(current_user) 
     end
   
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,6 +32,6 @@ class UsersController < ApplicationController
   end 
 
   def showedit
-    @products=current_user.selling_products
+    @products=current_user.selling_products.order("id DESC")
   end 
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -8,6 +8,8 @@ class Product < ApplicationRecord
   accepts_nested_attributes_for :product_images
   validates :title,:category_id,:shipping_charges,:shipping_area,:shipping_date,
             :shipping_method,:price,:size,:description,:condition,presence: true
+  validates :price, numericality: { greater_than_or_equal_to: 300  }
+  validates :price, numericality: { less_than_or_equal_to: 9999999 }
   enum condition:         ["新品、未使用","未使用に近い","目立った傷や汚れなし","やや傷や汚れあり","傷や汚れあり","全体的に状態が悪い"]
   enum shipping_charges:  ["送料込み(出品者負担)","着払い(購入者負担)"]
   enum shipping_date:     ["1~2日で発送","2~3日で発送","4~7日で発送"]

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -10,7 +10,7 @@
           %h2.single-head 商品の情報を入力 
           = form_for @product, html: {id:'edit_item', class:"sell-form"}  do |f|
             .item__images__container.sell-upload-box
-              %h3.sell-upload-head.block-image
+              %h3.sell-upload-head.block-image{data:{alreadysavedtotal:@product.product_images.length-1}}
                 出品画像
                 %span.form-require 必須
               %p 最大10枚までアップロードできます
@@ -23,7 +23,7 @@
                           .img-box
                             =image_tag product_image.image.url if product_image.image.url.present?
                           .item__images__container__preview__box
-                            %div.delete_btn_box
+                            %div.delete_btn_box2
                               .item__images__container__preview__box__delete
                                 削除
                   = ff.label :image, form:"image", class: "dropzone-box item__images__container__guide sell-upload-drop-box" ,for:"upload-image" do

--- a/app/views/products/update.json.jbuilder
+++ b/app/views/products/update.json.jbuilder
@@ -7,7 +7,7 @@ json.product_errors_size              @product.errors.messages[:size].present?  
 json.product_errors_condition         @product.errors.messages[:condition].present?         unless @product.valid?
 json.product_errors_shipping_charges  @product.errors.messages[:shipping_charges].present?  unless @product.valid?
 json.product_errors_shipping_method   @product.errors.messages[:shipping_method].present?   unless @product.valid?
-json.product_errors_shipping_area     @product.errors.messages[:shipping_area].present?      unless @product.valid?
+json.product_errors_shipping_area     @product.errors.messages[:shipping_area].present?     unless @product.valid?
 json.product_errors_shipping_date     @product.errors.messages[:shipping_date].present?     unless @product.valid?
 json.product_errors_price             @product.errors.messages[:price].present?             unless @product.valid?
-
+json.current_user_id                  @product.user.id                                      unless @product.valid?

--- a/app/views/users/_showedit_main.html.haml
+++ b/app/views/users/_showedit_main.html.haml
@@ -26,16 +26,18 @@
                     =image_tag product.product_images[0].image.url , class: "is-higher-width" 
                   .mypage-item-body
                     .mypage-item-text
-                      hdghg
+                      = product.title
                     %div
                       %span.listing-item-count
                         %i.icon
                           = icon("far", "heart")
-                        %span 0
+                        %span
+                          = product.likes.count
                       %span.listing-item-count
                         %i.icon
                           = icon("far", "comment")
-                        %span 0
+                        %span
+                          = product.comments.count
                       .mypage-item-status.bold.awaiting
                         出品中
         -else


### PR DESCRIPTION
#what
products#sellおよびproducts#editに以下2つの機能を実装する。
- 画像を10個以上アップデートできないようにJSでvalidate
- priceを300から9,999,999の範囲外のときはエラーを出力するよう変更

#why
商品出品および編集時にユーザーに正しいデータを入力することを促すため。