### PR TITLE
create transaction status

### DIFF
--- a/app/assets/javascripts/likes.js
+++ b/app/assets/javascripts/likes.js
@@ -7,7 +7,7 @@ $(function(){
   }else{
     $(".on-to-off").hide();
     $(".off-to-on").show();
-    $(".item-box-container__evaluation-btn__left__like").css("border","none");
+    $(".item-box-container__evaluation-btn__left__like").css("border","1px solid white");
 
   }
 });

--- a/app/assets/javascripts/modal.js
+++ b/app/assets/javascripts/modal.js
@@ -3,8 +3,6 @@ $(function(){
     e.preventDefault();
     $("#overlay").fadeIn();
   })
-});
-$(function(){
   $("#modal-close-btn").on("click",function(e){
     e.preventDefault();
     $('#overlay').fadeOut();

--- a/app/assets/javascripts/sell.js
+++ b/app/assets/javascripts/sell.js
@@ -24,7 +24,6 @@ $(function(){
       $(".overlay").fadeIn(200);
       $(".modal_exhibit-comp").fadeIn(200);
       var path="/products/" + data.product_id;
-      var path="/users/" + data.current_user_id + "/showedit";
       $(".link_to_product").attr("href",path);
     }
     else{

--- a/app/assets/javascripts/showedit.js
+++ b/app/assets/javascripts/showedit.js
@@ -1,0 +1,28 @@
+$(function(){
+
+  function pushed_productsTab(data){
+    $(".listing-tabs__tab").removeClass("active");
+    data.addClass("active");
+
+  }
+
+  function display_to_message_at_nonproduct(text){
+
+    $(".notpresent .gazou").empty();
+    $(".notpresent .gazou").html(text);
+
+  }
+
+  if(document.URL.match(/.+\/users\/.+\/showedit/)){
+    pushed_productsTab($(".tab_showedit"));
+    display_to_message_at_nonproduct("出品中の商品はありません");
+  }
+  else if(document.URL.match(/.+\/users\/.+\/show_transaction/)){
+    pushed_productsTab($(".tab_show_transaction"));
+    display_to_message_at_nonproduct("取引中の商品はありません");
+  }
+  else if(document.URL.match(/.+\/users\/.+\/show_completed/)){
+    pushed_productsTab($(".tab_show_completed"));
+    display_to_message_at_nonproduct("売却済みの商品はありません");
+  }
+});

--- a/app/assets/javascripts/showpurchase.js
+++ b/app/assets/javascripts/showpurchase.js
@@ -1,0 +1,24 @@
+$(function(){
+
+  function pushed_productsTab(data){
+    $(".listing-tabs__tab").removeClass("active");
+    data.addClass("active");
+
+  }
+
+  function display_to_message_at_nonproduct(text){
+
+    $(".notpresent .gazou").empty();
+    $(".notpresent .gazou").html(text);
+
+  }
+
+  if(document.URL.match(/.+\/users\/.+\/purchased/)){
+    pushed_productsTab($(".tab_purchased_completed"));
+    display_to_message_at_nonproduct("過去に取引した商品がありません");
+  }
+  else if(document.URL.match(/.+\/users\/.+\/purchase/)){
+    pushed_productsTab($(".tab_purchase_transaction"));
+    display_to_message_at_nonproduct("取引中の商品はありません");
+  }
+});

--- a/app/assets/javascripts/sidebar.js
+++ b/app/assets/javascripts/sidebar.js
@@ -8,31 +8,31 @@ $(function(){
     pushed_sidebar($(".side-mypage"));
   }
 
-  if(document.URL.match(/.+\/users\/notification/)){
+  if(document.URL.match(/.+\/users\/.+\/notification/)){
     pushed_sidebar($(".side-notification"));
   }
-  if(document.URL.match(/.+\/users\/todo/)){
+  if(document.URL.match(/.+\/users\/.+\/todo/)){
     pushed_sidebar($(".side-todo"));
   }
-  if(document.URL.match(/.+\/users\/like/)){
+  if(document.URL.match(/.+\/users\/.+\/like/)){
     pushed_sidebar($(".side-like"));
   }
-  if(document.URL.match(/.+\/users\/side-sell/)){
+  if(document.URL.match(/.+\/users\/.+\/side-sell/)){
     pushed_sidebar($(".side-sell"));
   }
-  if(document.URL.match(/.+\/users\/side-listings-listing/)){
+  if(document.URL.match(/.+\/users\/.+\/showedit/)){
     pushed_sidebar($(".side-listings-listing"));
   }
-  if(document.URL.match(/.+\/users\/side-listings-inprogress/)){
+  if(document.URL.match(/.+\/users\/.+\/show_transaction/)){
     pushed_sidebar($(".side-listings-inprogress"));
   }
-  if(document.URL.match(/.+\/users\/side-listings-complete/)){
+  if(document.URL.match(/.+\/users\/.+\/show_completed/)){
     pushed_sidebar($(".side-listings-complete"));
   }
-  if(document.URL.match(/.+\/users\/side-purchase/)){
+  if(document.URL.match(/.+\/users\/.+\/purchase/)){
     pushed_sidebar($(".side-purchase"));
   }
-  if(document.URL.match(/.+\/users\/side-purchased/)){
+  if(document.URL.match(/.+\/users\/.+\/purchased/)){
     pushed_sidebar($(".side-purchased"));
   }
   if(document.URL.match(/.+\/users\/side-news/)){

--- a/app/assets/stylesheets/_common_mypage.scss
+++ b/app/assets/stylesheets/_common_mypage.scss
@@ -4,6 +4,7 @@
   margin: 40px 0;
   width: 100%;
   .left-content{
+    display:block;
   }
   .right-content{
     width:100%;

--- a/app/assets/stylesheets/_modal.scss
+++ b/app/assets/stylesheets/_modal.scss
@@ -1,4 +1,4 @@
-#overlay {
+#overlay, #overlay_pend {
     width: 100%;
     height: 100%;
     position: fixed;
@@ -29,13 +29,29 @@
       flex-direction: column;
       justify-content: space-around;
     }
-    #modal-close-btn{
+    #modal-close-btn,#modal-close-btn_pend{
       width: 50%;
       height: 60px;
+      line-height:60px;
+    }
+    #modal-close-btn:hover,#modal-close-btn_pend:hover{
+      cursor:pointer;
+      background:grey;
+      
     }
     #delete-comformation-btn {
       width: 50%;
       height: 60px;
+      a{
+        display:block;
+        width:100%;
+        height:60px;
+        line-height:60px;
+      }
+    }
+    #delete-comformation-btn:hover {
+      cursor:pointer;
+      background:grey;
     }
   }
   .product-delete-btn {
@@ -45,17 +61,33 @@
     padding: 0;
     border: 0;
   }
-  #modal-open-btn{
+  .btn-red{
+    background:red;
+    color:white;
+    a{
+      color:white;
+    }
+  }
+  .btn-gray{
     background: #aaa;
-  border: 1px solid #aaa;
-  display: block;
-  width: 100%;
-  line-height: 48px;
-  font-size: 14px;
-  border: 1px solid transparent;
-  -webkit-transition: all ease-out .1s;
-  transition: all ease-out .1s;
-  cursor: pointer;
-  text-align: center;
-  margin: 16px 0 16px 0;
+    border: 1px solid #aaa;
+    color:white;
+  }
+  .btn-red:hover{
+    opacity:0.6;
+  }
+  .btn-gray:hover{
+    opacity:0.6;
+  }
+  #modal-open-btn{
+    display: block;
+    width: 100%;
+    line-height: 48px;
+    font-size: 14px;
+    border: 1px solid transparent;
+    -webkit-transition: all ease-out .1s;
+    transition: all ease-out .1s;
+    cursor: pointer;
+    text-align: center;
+    margin: 16px 0 16px 0;
   }

--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -1,7 +1,7 @@
 .item-box-container{
   background: #fff;
   margin: 40px auto 20px;
-  padding: 24px 16px 55px 16px;
+  padding: 24px 40px 40px;
 
   &__item-name{
     font-size: 24px;
@@ -44,6 +44,30 @@
               text-align:center;
               position:absolute;
               left:24%;
+              bottom:10px;
+              font-weight:bold;
+            }
+
+          }
+          &__pending-label{
+            position:absolute;
+            left:-66px;
+            top: -40px;
+            width:80%;
+            height:80px;
+            margin:auto auto 0 auto;
+            background:#888;
+            color:white;
+            font-size:18px;
+            text-align:center;
+            overflow: hidden;
+            transform: rotate(-45deg);
+            z-index:2;
+            p{
+              vertical-align : bottom;
+              text-align:center;
+              position:absolute;
+              left:15%;
               bottom:10px;
               font-weight:bold;
             }
@@ -375,32 +399,6 @@
     }
   }
   
-  .message-box_after-pay{
-    background:#ffffe0;
-    border-radius:4px;
-    width:100%;
-    padding:10px;
-    margin-bottom:10px;
-    &__inner{
-      width:60%;
-      margin:0 auto;
-      padding:10px 10px 0 10px;
-      // padding:
-      text-align:center;
-      &__head{
-        display:inline-block;
-        font-size:22px;
-        color:red;
-        .message-text{
-          font-weight:bold;
-
-        }
-      }
-      &__description{
-        padding:20px;
-      }
-    }
-  }
   &__item-state{
     font-size: 24px;
     text-align: center;
@@ -945,7 +943,8 @@
 
 @media screen and (min-width: 768px){
   .item-box-container{
-    padding: 24px 40px 24px 40px;
+    // padding: 24px 40px 24px 40px;
+    padding: 24px 40px 40px;
     width: 700px;
     background: #fff;
     margin: 40px auto 40px;

--- a/app/assets/stylesheets/_showedit.scss
+++ b/app/assets/stylesheets/_showedit.scss
@@ -2,7 +2,6 @@
     float: right;
     width: 700px;
     background: #fff;
-    height: 200px;
 }
 .mypage-tab-head {
     padding: 0 4%;
@@ -19,6 +18,9 @@
 }
 .listing-tabs li {
   width: 33.3%;
+}
+.listing-tabs .purchaselist {
+  width: 50%;
 }
 .listing-tabs li.active, .review-history-tabs li.active {
   background: #fff;
@@ -41,17 +43,37 @@
 }
 
 .mypage-item__link {
-  display: block;
   min-height: 80px;
-  padding: 16px;
-  color: gray;
-  &__figure {
-    position: relative;
-    overflow: hidden;
-    float: left;
-    width: 48px;
-    height: 48px;
+
+  .mypage-item__link__link{
+    display: block;
+    padding: 16px;
+    color: gray;
+    border-bottom:1px solid #eee;
+
+    &__wrapper{
+      display:flex;
+      justify-content: space-between;
+
+      &__main{
+        display:flex;
+
+        &__figure {
+          position: relative;
+          overflow: hidden;
+          width: 48px;
+          height: 48px;
+        }
+      }
+      &__icon{
+        display:block;
+        margin:auto 0;
+      }
+    }
   }
+}
+.mypage-item__link:hover{
+  background:#fafafa;
 }
 
 .mypage-item-list img.is-higher-width {
@@ -63,7 +85,8 @@
   transform: translate(-50%, 0);
 }
 .mypage-item-text{
-  margin: 0 5px 0 70px;
+  margin: 0 5px 4px 10px;
+  color:#333;
 }
 
 .is-higher-width {
@@ -81,8 +104,7 @@
   vertical-align: 2px;
   margin: 0 5px 0 10px;
 }
-.mypage-item-status.awaiting {
-  background: #0099e8;
+.mypage-item-status{
   display: inline-block;
   margin: 8px 0 0 0;
   padding: 5px 6px;
@@ -90,13 +112,31 @@
   font-size: 12px;
   color: #fff;
 }
-.gazou{
-  padding: 160px 0 60px;
-  background: url(img1.png);
-  background-repeat: no-repeat;
-  background-position: center 40px;
-  background-size: 100px 100px;
-  text-align: center;
-  font-size: 16px;
-  color: #ccc;
+
+.awaiting {
+  background: #0099e8;
+}
+.blueblock {
+  background: #0099e8;
+}
+
+.pending {
+  background:red;
+}
+.redblock {
+  background:red;
+}
+
+.notpresent{
+  background:#fff;
+  .gazou{
+    padding: 160px 0 60px;
+    background: url(https://www.mercari.com/jp/assets/img/common/common/logo-gray-icon.svg?39597161);
+    background-repeat: no-repeat;
+    background-position: center 40px;
+    background-size: 100px 100px;
+    text-align: center;
+    font-size: 16px;
+    color: #ccc;
+  }
 }

--- a/app/assets/stylesheets/_showmain.scss
+++ b/app/assets/stylesheets/_showmain.scss
@@ -32,3 +32,10 @@
   text-align: center;
   margin: 16px 0 16px 0;
 }
+.item-box-message{
+  .btn-red,.btn-gray{
+    a{
+      color:white;
+    }
+  }
+}

--- a/app/assets/stylesheets/_transaction.scss
+++ b/app/assets/stylesheets/_transaction.scss
@@ -1,0 +1,49 @@
+.item-box-container{
+
+  .message-box_after-pay{
+    background:#ffffe0;
+    border-radius:4px;
+    width:100%;
+    padding:10px;
+    margin-bottom:10px;
+    &__inner{
+      width:60%;
+      margin:0 auto;
+      padding:10px 10px 0 10px;
+      text-align:center;
+      &__head{
+        display:inline-block;
+        font-size:22px;
+        color:red;
+        .message-text{
+          font-weight:bold;
+
+        }
+      }
+      &__description{
+        padding:20px 0px 10px 0px;
+        line-height:1.6em;
+        .p1,.p2{
+          text-align:left;
+          padding-left:110px;
+        }
+        .p3,.p4{
+          text-align:left;
+          padding-left:80px;
+        }
+        .p5,.p6{
+          text-align:left;
+          padding-left:30px;
+        }
+      }
+    }
+  }
+  .to_complete_list{
+    margin-top:40px;
+    display:block;
+    text-align:center;
+    color:#0099e8;
+    font-size:18px;
+
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,6 +21,7 @@
 @import "showedit";
 @import "showmain";
 @import "modal";
+@import "transaction";
 // ログイン、サインアップ関連登録用
 @import "login/header&footer";
 @import "login/main";

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,6 @@
 class ProductsController < ApplicationController
-  before_action :set_product, only:[:edit, :update, :show, :pay,:buy]
+  before_action :set_product, only:[:edit, :update, :show, :pay, :buy, :destroy, :pend, :resell, :ship, :recieve, :close, :showmain, :show_transaction_main, :show_completed_main, :purchase_transaction, :purchase_completed]
+
   def index 
     @products = Product.order("id DESC").limit(5)
   end
@@ -92,10 +93,10 @@ class ProductsController < ApplicationController
       currency: 'jpy',            #日本円
     )
     @product.update(buyer_id: current_user.id)
+    @product.state_transition("waiting_for_shipping")
   end
 
   def showmain
-    @product= Product.find(params[:id])
     @products_this_seller = @product.user.products.order('id DESC').where.not(id: params[:id]).limit(6)
     @category = @product.category
     @products_this_category = @category.products.order('id DESC').where.not(user_id:@product.user).limit(6)
@@ -103,11 +104,38 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    @product= Product.find(params[:id])
     if @product.destroy
       redirect_to showedit_user_path(current_user)
     end
-  
+  end
+  def pend
+    @product.state_transition("pending")
+    redirect_to showmain_product_path(@product)
+  end
+  def resell
+    @product.state_transition("in_sale")
+    redirect_to showmain_product_path(@product)
+  end
+  def ship
+    @product.state_transition("on_delivery")
+    redirect_to show_transaction_main_product_path(@product)
+  end
+  def recieve
+    @product.state_transition("arrived")
+    redirect_to purchase_transaction_product_path(@product)
+  end
+  def close
+    @product.state_transition("completed")
+    redirect_to show_completed_main_product_path(@product)
+  end
+
+  def show_transaction_main
+  end
+  def show_completed_main
+  end
+  def purchase_transaction
+  end
+  def purchase_completed
   end
 
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+
   def index
   end
 
@@ -32,6 +33,20 @@ class UsersController < ApplicationController
   end 
 
   def showedit
-    @products=current_user.selling_products.order("id DESC")
+    @products=current_user.selling_products.where(state: ['in_sales' ,'pending']).order("id DESC")
   end 
+  def show_transaction
+    @products=current_user.sold_products.where(state: ['waiting_for_shipping', 'on_delivery' ,'arrived']).order("id DESC")
+  end
+  def show_completed
+    @products=current_user.sold_products.where(state: 'completed' ).order("id DESC")
+  end
+
+  def purchase
+    @products=current_user.sold_products.where(state: ['waiting_for_shipping', 'on_delivery', 'arrived']).order("id DESC")
+  end
+  def purchased
+    @products=current_user.sold_products.where(state: 'completed' ).order("id DESC")
+  end
+
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -15,4 +15,9 @@ class Product < ApplicationRecord
   enum shipping_date:     ["1~2日で発送","2~3日で発送","4~7日で発送"]
   enum shipping_method:   ["未定","クロネコヤマト","ゆうパック","ゆうメール"]
   enum size:              ["XXS以下","XS(SS)","S","M","L","XL(LL)","2XL(3L)","3XL(4L)","4XL(5L)以上","FREE SIZE"]
+  enum state:              { in_sale: 0, waiting_for_shipping: 1, on_delivery: 2, arrived: 3, completed: 10, pending: 99 }
+
+  def state_transition(state)
+    self.update(state: state)
+  end
 end

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -28,19 +28,19 @@
           出品した商品 - 出品中
           = icon("fas", "angle-right side-box__mypage-nav__list__inner__item__icon fa-1g")
       %li.side-box__mypage-nav__list__inner
-        =link_to "", class:"side-box__mypage-nav__list__inner__item side-listings-inprogress" do
+        =link_to show_transaction_user_path(current_user), class:"side-box__mypage-nav__list__inner__item side-listings-inprogress" do
           出品した商品 - 取引中
           = icon("fas", "angle-right side-box__mypage-nav__list__inner__item__icon fa-1g")
       %li.side-box__mypage-nav__list__inner
-        =link_to "", class:"side-box__mypage-nav__list__inner__item side-listings-complete" do
+        =link_to show_completed_user_path(current_user), class:"side-box__mypage-nav__list__inner__item side-listings-complete" do
           出品した商品 - 売却済み
           = icon("fas", "angle-right side-box__mypage-nav__list__inner__item__icon fa-1g")
       %li.side-box__mypage-nav__list__inner
-        =link_to "", class:"side-box__mypage-nav__list__inner__item side-purchase" do
+        =link_to purchase_user_path(current_user), class:"side-box__mypage-nav__list__inner__item side-purchase" do
           購入した商品 - 取引中
           = icon("fas", "angle-right side-box__mypage-nav__list__inner__item__icon fa-1g")
       %li.side-box__mypage-nav__list__inner
-        =link_to "", class:"side-box__mypage-nav__list__inner__item side-purchased" do
+        =link_to purchased_user_path(current_user), class:"side-box__mypage-nav__list__inner__item side-purchased" do
           購入した商品 - 過去の取引
           = icon("fas", "angle-right side-box__mypage-nav__list__inner__item__icon fa-1g")
       %li.side-box__mypage-nav__list__inner

--- a/app/views/likes/destroy.js.erb
+++ b/app/views/likes/destroy.js.erb
@@ -1,4 +1,4 @@
 $(".on-to-off").hide();
 $(".off-to-on").show();
 $(".fade-in-down").html(<%=@like_count%>);
-$(".item-box-container__evaluation-btn__left__like").css("border","none");
+$(".item-box-container__evaluation-btn__left__like").css("border","1px solid white");

--- a/app/views/products/pay.html.haml
+++ b/app/views/products/pay.html.haml
@@ -25,6 +25,6 @@
       - else
         着払い   
   .item-box-container__link
-    = link_to "", class:"item-buy-btn" do
+    = link_to purchase_user_path(current_user), class:"item-buy-btn" do
       購入した商品のステータスを確認する
 = render "layouts/footer"

--- a/app/views/products/purchase_completed.html.haml
+++ b/app/views/products/purchase_completed.html.haml
@@ -1,0 +1,14 @@
+= render "layouts/header"
+%section.item-box-container
+  - if @product.state == "completed"
+    .message-box_after-pay
+      .message-box_after-pay__inner
+        .message-box_after-pay__inner__head
+          = icon("fas", "fa-check icon-time fa-lg")
+          %span.message-text
+            取引完了
+        .message-box_after-pay__inner__description
+          %p.p1 この商品の取引はクローズしました。
+    = link_to purchased_user_path(current_user), class:"to_complete_list" do
+      購入した商品 - 過去の取引へ
+= render "layouts/footer"

--- a/app/views/products/purchase_transaction.html.haml
+++ b/app/views/products/purchase_transaction.html.haml
@@ -1,0 +1,81 @@
+= render "layouts/header"
+%section.item-box-container
+  - if @product.state == "waiting_for_shipping"
+    .message-box_after-pay
+      .message-box_after-pay__inner
+        .message-box_after-pay__inner__head
+          = icon("far", "clock icon-time fa-lg")
+          %span.message-text
+            発送をお待ちください
+        .message-box_after-pay__inner__description
+          出品者からの発送通知をお待ちください
+    %h1.item-box-container__item-state
+      購入が完了しました
+    .item-box-container__photo-box
+      .item-box-container__photo-box__inner
+        = image_tag @product.product_images[0].image.url, class:"image_photo_pay"
+    %h1.item-box-container__item-name
+      = @product.title
+    .item-box-container__price-box
+      %span.item-box-container__price-box__price
+        = "¥#{@product.price.to_s(:delimited)}"
+      %span.item-box-container__price-box__tax (税込)
+      %span.item-box-container__price-box__shipping-fee
+        - if @product.shipping_charges_before_type_cast == 0
+          送料込み
+        - else
+          着払い   
+    .item-box-container__link
+      = link_to purchase_user_path(current_user), class:"item-buy-btn" do
+        購入した商品のステータスを確認する
+
+  - elsif @product.state == "on_delivery"
+    .message-box_after-pay
+      .message-box_after-pay__inner
+        .message-box_after-pay__inner__head
+          %i.fas.fa-laugh.icon-laugh.evaluation-mark
+          %span.message-text
+            商品が発送されました。
+        .message-box_after-pay__inner__description
+          %p.p3 商品が発送されました。商品が到着したら、
+          %p.p4 出品者の評価をしてください。
+    %h1.item-box-container__item-state
+      評価
+    .item-box-container__photo-box
+      .item-box-container__photo-box__inner
+        = image_tag @product.product_images[0].image.url, class:"image_photo_pay"
+    %h1.item-box-container__item-name
+      = @product.title
+    %button#modal-open-btn.btn-default.btn-red
+      = link_to "商品の受領したので、受取通知をする", ""
+
+  - elsif @product.state == "arrived"
+    .message-box_after-pay
+      .message-box_after-pay__inner
+        .message-box_after-pay__inner__head
+          %i.fas.fa-laugh.icon-laugh.evaluation-mark
+          %span.message-text
+            購入者へ商品の受取を通知しました
+        .message-box_after-pay__inner__description
+          %p.p5 最後に、出品者による取引完了処理を持って
+          %p.p6 取引は完了となります。
+    %h1.item-box-container__item-state
+      取引完了待ち
+    .item-box-container__photo-box
+      .item-box-container__photo-box__inner
+        = image_tag @product.product_images[0].image.url, class:"image_photo_pay"
+    %h1.item-box-container__item-name
+      = @product.title
+    .item-box-container__link
+      = link_to purchase_user_path(current_user), class:"item-buy-btn" do
+        取引のステータスを確認する
+= render "layouts/footer"
+
+
+#overlay.hidden
+  #modalWindow
+    .modal-message-box
+      %div 受取処理を完了させる
+    #modal-close-btn キャンセル
+    #delete-comformation-btn
+      = link_to "OK", recieve_product_path(@product)

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -135,7 +135,8 @@
               = icon("fas", "heart icon-like-border fa-lg" )
               %span いいね!
         %span.fade-in-down{data:{num:"like"}}
-          -# = @likes.count
+          -if user_signed_in?
+            = @likes.count
       = link_to "" , class:"item-button item-button-report", data: { modal:"report-item", open: "modal"} do
         = icon("far", "flag icon-flag fa-lg")
         %span 不適切な商品の報告

--- a/app/views/products/show_completed_main.html.haml
+++ b/app/views/products/show_completed_main.html.haml
@@ -1,0 +1,14 @@
+= render "layouts/header"
+%section.item-box-container
+  - if @product.state == "completed"
+    .message-box_after-pay
+      .message-box_after-pay__inner
+        .message-box_after-pay__inner__head
+          = icon("fas", "fa-check icon-time fa-lg")
+          %span.message-text
+            取引完了
+        .message-box_after-pay__inner__description
+          %p.p1 この商品の取引はクローズしました。
+    = link_to show_completed_user_path(current_user), class:"to_complete_list" do
+      出品した商品 - 売却済みへ
+= render "layouts/footer"

--- a/app/views/products/show_transaction_main.html.haml
+++ b/app/views/products/show_transaction_main.html.haml
@@ -1,0 +1,95 @@
+= render "layouts/header"
+%section.item-box-container
+  - if @product.state == "waiting_for_shipping"
+    .message-box_after-pay
+      .message-box_after-pay__inner
+        .message-box_after-pay__inner__head
+          = icon("fas", "truck-moving icon-time fa-lg")
+          %span.message-text
+            発送してください
+        .message-box_after-pay__inner__description
+          %p.p1 商品が購入され支払いされました。
+          %p.p2 商品の発送を行ってください。
+    %h1.item-box-container__item-state
+      出品商品が購入されました
+    .item-box-container__photo-box
+      .item-box-container__photo-box__inner
+        = image_tag @product.product_images[0].image.url, class:"image_photo_pay"
+    %h1.item-box-container__item-name
+      = @product.title
+    .item-box-container__price-box
+      %span.item-box-container__price-box__price
+        = "¥#{@product.price.to_s(:delimited)}"
+      %span.item-box-container__price-box__tax (税込)
+      %span.item-box-container__price-box__shipping-fee
+        - if @product.shipping_charges_before_type_cast == 0
+          送料込み
+        - else
+          着払い   
+    %button#modal-open-btn.btn-default.btn-red
+      = link_to "商品の発送をしたので、発送通知をする", ""
+  - elsif @product.state == "on_delivery"
+    .message-box_after-pay
+      .message-box_after-pay__inner
+        .message-box_after-pay__inner__head
+          = icon("fas", "truck-moving icon-time fa-lg")
+          %span.message-text
+            配達中です
+        .message-box_after-pay__inner__description
+          %p.p1 購入者からの受取通知をお待ちください
+    %h1.item-box-container__item-state
+      購入者からの受取通知待ち
+    .item-box-container__photo-box
+      .item-box-container__photo-box__inner
+        = image_tag @product.product_images[0].image.url, class:"image_photo_pay"
+    %h1.item-box-container__item-name
+      = @product.title
+    .item-box-container__link
+      = link_to show_transaction_user_path(current_user), class:"item-buy-btn" do
+        出品した商品のステータスを確認する
+  - elsif @product.state == "arrived"
+    .message-box_after-pay
+      .message-box_after-pay__inner
+        .message-box_after-pay__inner__head
+          %i.fas.fa-laugh.icon-laugh.evaluation-mark
+          %span.message-text
+            取引を完了させてください
+        .message-box_after-pay__inner__description
+          %p.p3 購入から商品が到着し評価がありました。
+          %p.p4 購入者の評価を行って取引を完了させてください。
+    %h1.item-box-container__item-state
+      取引完了手続き
+    .item-box-container__photo-box
+      .item-box-container__photo-box__inner
+        = image_tag @product.product_images[0].image.url, class:"image_photo_pay"
+    %h1.item-box-container__item-name
+      = @product.title
+    .item-box-container__price-box
+      %span.item-box-container__price-box__price
+        = "¥#{@product.price.to_s(:delimited)}"
+      %span.item-box-container__price-box__tax (税込)
+      %span.item-box-container__price-box__shipping-fee
+        - if @product.shipping_charges_before_type_cast == 0
+          送料込み
+        - else
+          着払い   
+    %button#modal-open-btn.btn-default.btn-red
+      = link_to "取引完了", ""
+
+
+= render "layouts/footer"
+
+#overlay.hidden
+  #modalWindow
+    - if @product.state == "waiting_for_shipping"
+      .modal-message-box
+        %div 発送通知をする
+      #modal-close-btn キャンセル
+      #delete-comformation-btn
+        = link_to "OK", ship_product_path(@product)
+    - elsif @product.state == "arrived"
+      .modal-message-box
+        %div 取引を完了しますか？
+      #modal-close-btn キャンセル
+      #delete-comformation-btn
+        = link_to "OK", close_product_path(@product)

--- a/app/views/products/showmain.html.haml
+++ b/app/views/products/showmain.html.haml
@@ -6,6 +6,12 @@
     .item-box-container__main__photo
       .item-box-container__main__photo__inner
         .item-box-container__main__photo__inner__large-box
+          - if @product.state == "pending"
+            .item-box-container__main__photo__inner__large-box__pending-label
+              %p 公開停止中
+          - elsif @product.buyer
+            .item-box-container__main__photo__inner__large-box__sold-label
+              %p SOLD
           .item-box-container__main__photo__inner__large-box__wrapper
             - if @product 
               - @product.product_images.each do | product_image |
@@ -108,10 +114,16 @@
   = link_to edit_product_path(@product) ,class: "btn-default btn-red"do
     商品の編集
   %p.text-center or
-  %button.btn-default.btn-gray
-    = link_to "出品を一旦停止する",""   
+  -if @product.state == "in_sale" 
+    %button.btn-default.btn-gray
+      = link_to "出品を一旦停止する",pend_product_path(@product)
+  -elsif @product.state == "pending"
+    %button.btn-default.btn-red
+      = link_to "出品を再開する",resell_product_path(@product)   
   %button#modal-open-btn.btn-gray
     = link_to "この商品を削除する", ""
+
+
 #overlay.hidden
   #modalWindow
     .modal-message-box
@@ -120,6 +132,7 @@
     #modal-close-btn キャンセル
     #delete-comformation-btn
       = link_to "削除する",product_path(@product), method: :DELETE 
+
 .item-box-message
   .item-box-message__container
     .item-box-message__container__content

--- a/app/views/users/_notification.html.haml
+++ b/app/views/users/_notification.html.haml
@@ -2,11 +2,11 @@
   %ul.mypage-tabs__do
     %li.active
       %h3
-        = link_to notification_users_path , class: "oshirase-tag" , data:{toggle:"tab"} do
+        = link_to notification_user_path(current_user) , class: "oshirase-tag" , data:{toggle:"tab"} do
           お知らせ
     %li
       %h3
-        = link_to todo_users_path , class: "todo-tag" , data:{toggle:"tab"} do
+        = link_to todo_user_path(current_user) , class: "todo-tag" , data:{toggle:"tab"} do
           やることリスト
   %ul.mypage-item
     - if @notifications

--- a/app/views/users/_purchase_main.html.haml
+++ b/app/views/users/_purchase_main.html.haml
@@ -1,0 +1,77 @@
+%section.mypage-tab-container
+  %h2.mypage-tab-head 購入した商品
+  %ul.listing-tabs
+    %li.listing-tabs__tab.purchaselist.tab_purchase_transaction
+      %h3
+        = link_to   purchase_user_path(current_user), data:{toggle:"tab"} do
+          取引中
+    %li.listing-tabs__tab.purchaselist.tab_purchased_completed
+      %h3
+        = link_to   purchased_user_path(current_user),   data:{toggle:"tab"} do
+          過去の取引
+  .tab-content
+    %ul.mypage-item
+      - if @products.present?
+        -@products.each do | product |
+          %li
+            .mypage-item__link
+              - if product.state == "waiting_for_shipping" || product.state == "on_delivery" || product.state == "arrived" 
+                = link_to purchase_transaction_product_path(product), class: "mypage-item__link__link"  do
+                  .mypage-item__link__link__wrapper
+                    .mypage-item__link__link__wrapper__main
+                      .mypage-item__link__link__wrapper__main__figure
+                        =image_tag product.product_images[0].image.url , class: "is-higher-width" 
+                      .mypage-item-body
+                        .mypage-item-text
+                          = product.title
+                        %div
+                          %span.listing-item-count
+                            %i.icon
+                              = icon("far", "heart")
+                            %span
+                              = product.likes.count
+                          %span.listing-item-count
+                            %i.icon
+                              = icon("far", "comment")
+                            %span
+                              = product.comments.count
+                          - if product.state == "waiting_for_shipping"
+                            .mypage-item-status.bold.blueblock
+                              発送待ち
+                          - elsif product.state == "on_delivery"
+                            .mypage-item-status.bold.redblock
+                              配達中
+                          - elsif product.state == "arrived"
+                            .mypage-item-status.bold.blueblock
+                              出品者による完了処置中
+                    .mypage-item__link__link__wrapper__icon
+                      = icon("fas", "angle-right fa-2x")
+              - elsif product.state == "completed"
+                = link_to purchase_completed_product_path(product), class: "mypage-item__link__link"  do
+                  .mypage-item__link__link__wrapper
+                    .mypage-item__link__link__wrapper__main
+                      .mypage-item__link__link__wrapper__main__figure
+                        =image_tag product.product_images[0].image.url , class: "is-higher-width" 
+                      .mypage-item-body
+                        .mypage-item-text
+                          = product.title
+                        %div
+                          %span.listing-item-count
+                            %i.icon
+                              = icon("far", "heart")
+                            %span
+                              = product.likes.count
+                          %span.listing-item-count
+                            %i.icon
+                              = icon("far", "comment")
+                            %span
+                              = product.comments.count
+                          - if  product.state == "completed"
+                            .mypage-item-status.bold.blueblock
+                              取引完了
+                    .mypage-item__link__link__wrapper__icon
+                      = icon("fas", "angle-right fa-2x")
+      -else
+        %li.notpresent
+          %h3.gazou
+            出品中の商品は現在ありません

--- a/app/views/users/_showedit_main.html.haml
+++ b/app/views/users/_showedit_main.html.haml
@@ -1,44 +1,118 @@
-.l-content
-  %section.mypage-tab-container
-    %h2.mypage-tab-head 出品した商品
-    %ul.listing-tabs
-      %li.active
-        %h3
-          = link_to "#mypage-tab-transaction-now" , data:{toggle:"tab"} do
-            出品中
-      %li
-        %h3
-          = link_to "/jp/mypage/listings/in_progress/", data:{toggle:"tab"} do
-            取引中
-      %li
-        %h3
-          = link_to "/jp/mypage/listings/completed/", data:{toggle:"tab"} do
-            売却済み
-    .tab-content
-      %ul.mypage-item
-        -if @products
-          -@products.each do | product |
-            %li
-              .mypage-item__link
-
-                = link_to showmain_product_path(product), class: "mypage-item-link"  do
-                  .mypage-item__link__figure
-                    =image_tag product.product_images[0].image.url , class: "is-higher-width" 
-                  .mypage-item-body
-                    .mypage-item-text
-                      = product.title
-                    %div
-                      %span.listing-item-count
-                        %i.icon
-                          = icon("far", "heart")
-                        %span
-                          = product.likes.count
-                      %span.listing-item-count
-                        %i.icon
-                          = icon("far", "comment")
-                        %span
-                          = product.comments.count
-                      .mypage-item-status.bold.awaiting
-                        出品中
-        -else
-          %h3.gazou "出品中の商品は現在ありません”
+%section.mypage-tab-container
+  %h2.mypage-tab-head 出品した商品
+  %ul.listing-tabs
+    %li.listing-tabs__tab.tab_showedit
+      %h3
+        = link_to   showedit_user_path(current_user),         data:{toggle:"tab"} do
+          出品中
+    %li.listing-tabs__tab.tab_show_transaction
+      %h3
+        = link_to   show_transaction_user_path(current_user), data:{toggle:"tab"} do
+          取引中
+    %li.listing-tabs__tab.tab_show_completed
+      %h3
+        = link_to   show_completed_user_path(current_user),   data:{toggle:"tab"} do
+          売却済み
+  .tab-content
+    %ul.mypage-item
+      - if @products.present?
+        -@products.each do | product |
+          %li
+            .mypage-item__link
+              - if product.state == "in_sale" || product.state == "pending"
+                = link_to showmain_product_path(product), class: "mypage-item__link__link"  do
+                  .mypage-item__link__link__wrapper
+                    .mypage-item__link__link__wrapper__main
+                      .mypage-item__link__link__wrapper__main__figure
+                        =image_tag product.product_images[0].image.url , class: "is-higher-width" 
+                      .mypage-item-body
+                        .mypage-item-text
+                          = product.title
+                        %div
+                          %span.listing-item-count
+                            %i.icon
+                              = icon("far", "heart")
+                            %span
+                              = product.likes.count
+                          %span.listing-item-count
+                            %i.icon
+                              = icon("far", "comment")
+                            %span
+                              = product.comments.count
+                          - if product.state == "in_sale"
+                            .mypage-item-status.bold.awaiting
+                              出品中
+                          - elsif  product.state == "pending"
+                            .mypage-item-status.bold.pending
+                              公開停止中
+                          - elsif product.state == "waiting_for_shipping"
+                            .mypage-item-status.bold.pending
+                              発送待ち
+                          - elsif product.state == "on_delivery"
+                            .mypage-item-status.bold.awaiting
+                              配達中
+                          - elsif  product.state == "arrived"
+                            .mypage-item-status.bold.pending
+                              受取評価待ち
+                    .mypage-item__link__link__wrapper__icon
+                      = icon("fas", "angle-right fa-2x")
+              - elsif product.state == "waiting_for_shipping" || product.state == "on_delivery" || product.state == "arrived"
+                = link_to show_transaction_main_product_path(product), class: "mypage-item__link__link"  do
+                  .mypage-item__link__link__wrapper
+                    .mypage-item__link__link__wrapper__main
+                      .mypage-item__link__link__wrapper__main__figure
+                        =image_tag product.product_images[0].image.url , class: "is-higher-width" 
+                      .mypage-item-body
+                        .mypage-item-text
+                          = product.title
+                        %div
+                          %span.listing-item-count
+                            %i.icon
+                              = icon("far", "heart")
+                            %span
+                              = product.likes.count
+                          %span.listing-item-count
+                            %i.icon
+                              = icon("far", "comment")
+                            %span
+                              = product.comments.count
+                          - if product.state == "waiting_for_shipping"
+                            .mypage-item-status.bold.redblock
+                              発送待ち
+                          - elsif product.state == "on_delivery"
+                            .mypage-item-status.bold.awaiting
+                              配達中
+                          - elsif  product.state == "arrived"
+                            .mypage-item-status.bold.pending
+                              完了処置待ち
+                    .mypage-item__link__link__wrapper__icon
+                      = icon("fas", "angle-right fa-2x")
+              - elsif product.state == "completed"
+                = link_to show_completed_main_product_path(product), class: "mypage-item__link__link"  do
+                  .mypage-item__link__link__wrapper
+                    .mypage-item__link__link__wrapper__main
+                      .mypage-item__link__link__wrapper__main__figure
+                        =image_tag product.product_images[0].image.url , class: "is-higher-width" 
+                      .mypage-item-body
+                        .mypage-item-text
+                          = product.title
+                        %div
+                          %span.listing-item-count
+                            %i.icon
+                              = icon("far", "heart")
+                            %span
+                              = product.likes.count
+                          %span.listing-item-count
+                            %i.icon
+                              = icon("far", "comment")
+                            %span
+                              = product.comments.count
+                          - if product.state == "completed"
+                            .mypage-item-status.bold.awaiting
+                              取引完了
+                    .mypage-item__link__link__wrapper__icon
+                      = icon("fas", "angle-right fa-2x")
+      -else
+        %li.notpresent
+          %h3.gazou
+            出品中の商品は現在ありません

--- a/app/views/users/_todo.html.haml
+++ b/app/views/users/_todo.html.haml
@@ -2,11 +2,11 @@
   %ul.mypage-tabs__do
     %li
       %h3
-        = link_to notification_users_path , class: "oshirase-tag" , data:{toggle:"tab"} do
+        = link_to notification_user_path(current_user) , class: "oshirase-tag" , data:{toggle:"tab"} do
           お知らせ
     %li.active
       %h3
-        = link_to todo_users_path , class: "todo-tag" , data:{toggle:"tab"} do
+        = link_to todo_user_path(current_user) , class: "todo-tag" , data:{toggle:"tab"} do
           やることリスト
   %ul.mypage-item
     - if @todos

--- a/app/views/users/purchase.html.haml
+++ b/app/views/users/purchase.html.haml
@@ -1,0 +1,11 @@
+= render "layouts/header"
+%nav.gretel
+  - breadcrumb :showedit
+  = breadcrumbs separator: "＞"
+= render "layouts/exhibit__btn"
+%section.mypage-wrapper
+  .left-content
+    = render "layouts/sidebar"
+  .right-content
+    = render "purchase_main"
+= render "layouts/footer"

--- a/app/views/users/purchased.html.haml
+++ b/app/views/users/purchased.html.haml
@@ -1,0 +1,11 @@
+= render "layouts/header"
+%nav.gretel
+  - breadcrumb :showedit
+  = breadcrumbs separator: "＞"
+= render "layouts/exhibit__btn"
+%section.mypage-wrapper
+  .left-content
+    = render "layouts/sidebar"
+  .right-content
+    = render "purchase_main"
+= render "layouts/footer"

--- a/app/views/users/show_completed.html.haml
+++ b/app/views/users/show_completed.html.haml
@@ -1,0 +1,11 @@
+= render "layouts/header"
+%nav.gretel
+  - breadcrumb :showedit
+  = breadcrumbs separator: "＞"
+= render "layouts/exhibit__btn"
+%section.mypage-wrapper
+  .left-content
+    = render "layouts/sidebar"
+  .right-content
+    = render "showedit_main"
+= render "layouts/footer"

--- a/app/views/users/show_transaction.haml
+++ b/app/views/users/show_transaction.haml
@@ -1,0 +1,11 @@
+= render "layouts/header"
+%nav.gretel
+  - breadcrumb :showedit
+  = breadcrumbs separator: "＞"
+= render "layouts/exhibit__btn"
+%section.mypage-wrapper
+  .left-content
+    = render "layouts/sidebar"
+  .right-content
+    = render "showedit_main"
+= render "layouts/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,17 @@ Rails.application.routes.draw do
     end
     member do 
       get :showmain
+      get :show_transaction_main
+      get :show_completed_main
+      get :purchase_transaction
+      get :purchase_completed
       get :buy
       get :pay
+      get :ship
+      get :recieve
+      get :pend
+      get :resell
+      get :close
     end
 
   end
@@ -27,6 +36,10 @@ Rails.application.routes.draw do
       get :todo
       get :like
       get :showedit
+      get :show_transaction
+      get :show_completed
+      get :purchase
+      get :purchased
     end
   end
   resources :trials, only: [:index,:create,:new, :edit, :update]

--- a/db/migrate/20191025192103_add_state_to_products.rb
+++ b/db/migrate/20191025192103_add_state_to_products.rb
@@ -1,0 +1,5 @@
+class AddStateToProducts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :products, :state, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_23_100533) do
+ActiveRecord::Schema.define(version: 2019_10_25_192103) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -123,6 +123,7 @@ ActiveRecord::Schema.define(version: 2019_10_23_100533) do
     t.datetime "updated_at", null: false
     t.integer "brand_id"
     t.integer "buyer_id"
+    t.integer "state", default: 0
     t.index ["category_id"], name: "index_products_on_category_id"
     t.index ["user_id"], name: "index_products_on_user_id"
   end


### PR DESCRIPTION
#what
- products tableにstate columnを追加
state columnに入るintegerに以下のenumを状態として割り当て
  - in_sale
     出品中
  - waiting_for_shipping
     発送待ち
  - on_derively
     配送中
  - arrived
     購入者受取
  - completed
     取引クローズ
  - pending
     出品一旦停止
- 上記状態に繊維するためのアクションとして、products_controllerに次のアクションを追加する
  - ship
     発送処理手続き
  - recieve
     商品受取り手続き
  - pend
     一旦停止手続き
  - resell
     出品再開手続き
  - close
     取引完了手続き
  - show_transaction_main
    取引処理フォーム(出品者)への遷移アクション
  - show_completed_main
　取引完了後の遷移アクション
  - purchase_transaction
　取引処理フォーム(購入者)への遷移アクション
  - purchase_completed
　取引完了後の遷移アクション

- users_controllerに次のアクションを追加する
  - show_transaction
    マイページにおける出品した商品の取引中
  -  show_completed
     マイページにおける出品した商品の売却済み
  - purchase
    マイページにおける購入した商品の取引中
   - purchased
      マイページにおける購入した商品の過去の取引

#why
出品した商品の状況を管理するため